### PR TITLE
1/19

### DIFF
--- a/lib/models/image_detail_bloc.dart
+++ b/lib/models/image_detail_bloc.dart
@@ -1,0 +1,7 @@
+
+
+class ImageDetailBloc {
+
+
+
+}

--- a/lib/models/image_upload_bloc.dart
+++ b/lib/models/image_upload_bloc.dart
@@ -3,7 +3,9 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:filesize/filesize.dart';
 import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:image_share_app/widgets/commont_widgets/common_loading_widget.dart';
 
@@ -30,6 +32,7 @@ class ImageUploadBloc extends AbstractLoadingBloc {
 
   /// FireStorageに画像をアップロード
   void uploadImage(File file, String roomId) async {
+    debugPrint(filesize(file.lengthSync()));
     _loadingController.sink.add(LoadingType.LOADING);
     _repository.uploadImageToFireStorage(file, roomId);
     _loadingController.sink.add(LoadingType.COMPLETED);

--- a/lib/models/image_upload_bloc.dart
+++ b/lib/models/image_upload_bloc.dart
@@ -52,6 +52,7 @@ class ImageUploadRepository {
     return await ImagePicker.pickImage(source: ImageSource.gallery);
   }
 
+  /// FireStorageに画像をアップロードする
   Future uploadImageToFireStorage(File file, String roomId) async {
     int timestamp = DateTime.now().millisecondsSinceEpoch;
 

--- a/lib/widgets/image_detail/image_detail_page.dart
+++ b/lib/widgets/image_detail/image_detail_page.dart
@@ -4,12 +4,36 @@ import 'package:flutter/material.dart';
 
 class ImageDetailPage extends StatelessWidget {
 
+  final String thumbnailUrl;
+
+  ImageDetailPage(this.thumbnailUrl);
+
   @override
   Widget build(BuildContext context) {
     // TODO: implement build
     return Scaffold(
       appBar: AppBar(title: const Text('詳細'),),
-      body: Container(),
+      body: _LayoutDetailImage(thumbnailUrl),
+    );
+  }
+}
+
+class _LayoutDetailImage extends StatelessWidget {
+
+  final String thumbnailUrl;
+
+  _LayoutDetailImage(this.thumbnailUrl);
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO: implement build
+    return Container(
+      padding: const EdgeInsets.all(3),
+      child: Image(
+        fit: BoxFit.contain,
+        width: MediaQuery.of(context).size.width,
+        image: NetworkImage(thumbnailUrl),
+      ),
     );
   }
 }

--- a/lib/widgets/image_detail/image_detail_page.dart
+++ b/lib/widgets/image_detail/image_detail_page.dart
@@ -1,0 +1,15 @@
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class ImageDetailPage extends StatelessWidget {
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO: implement build
+    return Scaffold(
+      appBar: AppBar(title: const Text('詳細'),),
+      body: Container(),
+    );
+  }
+}

--- a/lib/widgets/image_detail/image_detail_page.dart
+++ b/lib/widgets/image_detail/image_detail_page.dart
@@ -1,28 +1,29 @@
 
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class ImageDetailPage extends StatelessWidget {
 
-  final String thumbnailUrl;
+  final DocumentSnapshot imageDocument;
 
-  ImageDetailPage(this.thumbnailUrl);
+  ImageDetailPage(this.imageDocument);
 
   @override
   Widget build(BuildContext context) {
     // TODO: implement build
     return Scaffold(
       appBar: AppBar(title: const Text('詳細'),),
-      body: _LayoutDetailImage(thumbnailUrl),
+      body: _LayoutDetailImage(imageDocument),
     );
   }
 }
 
 class _LayoutDetailImage extends StatelessWidget {
 
-  final String thumbnailUrl;
+  final DocumentSnapshot imageDocument;
 
-  _LayoutDetailImage(this.thumbnailUrl);
+  _LayoutDetailImage(this.imageDocument);
 
   @override
   Widget build(BuildContext context) {
@@ -32,7 +33,7 @@ class _LayoutDetailImage extends StatelessWidget {
       child: Image(
         fit: BoxFit.contain,
         width: MediaQuery.of(context).size.width,
-        image: NetworkImage(thumbnailUrl),
+        image: NetworkImage(imageDocument.data['originalUrl']),
       ),
     );
   }

--- a/lib/widgets/top_image_list/top_image_list.dart
+++ b/lib/widgets/top_image_list/top_image_list.dart
@@ -5,6 +5,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:image_share_app/models/top_image_bloc.dart';
 import 'package:image_share_app/widgets/commont_widgets/common_loading_widget.dart';
+import 'package:image_share_app/widgets/image_detail/image_detail_page.dart';
 import 'package:image_share_app/widgets/top_image_list/image_upload_page.dart';
 import 'package:provider/provider.dart';
 
@@ -55,27 +56,30 @@ class _ImagesWidget extends StatelessWidget {
               crossAxisCount: 2,
             ),
             itemBuilder: (context, index) {
-              return Container(
-                decoration: BoxDecoration(
-                  border: Border.all(color: Colors.black45),
-                ),
-                child: Image(
-                  fit: BoxFit.cover,
-                  image: (snapshot.hasData)
-                    ? NetworkImage(snapshot.data[index])
-                    : Card(color: Colors.orange,),
-                  loadingBuilder: (BuildContext context, Widget child, ImageChunkEvent loadingProgress) {
-                    if (loadingProgress == null) {
-                      return child;
-                    }
-                    return Center(
-                      child: CircularProgressIndicator(
-                        value: loadingProgress.expectedTotalBytes != null
-                        ? loadingProgress.cumulativeBytesLoaded / loadingProgress.expectedTotalBytes
-                            : null,
-                      ),
-                    );
-                  },
+              return GestureDetector(
+                onTap: () => Navigator.push(context, MaterialPageRoute(builder: (context) => ImageDetailPage())),
+                child: Container(
+                  decoration: BoxDecoration(
+                    border: Border.all(color: Colors.black45),
+                  ),
+                  child: Image(
+                    fit: BoxFit.cover,
+                    image: (snapshot.hasData)
+                      ? NetworkImage(snapshot.data[index])
+                      : Card(color: Colors.orange,),
+                    loadingBuilder: (BuildContext context, Widget child, ImageChunkEvent loadingProgress) {
+                      if (loadingProgress == null) {
+                        return child;
+                      }
+                      return Center(
+                        child: CircularProgressIndicator(
+                          value: loadingProgress.expectedTotalBytes != null
+                          ? loadingProgress.cumulativeBytesLoaded / loadingProgress.expectedTotalBytes
+                              : null,
+                        ),
+                      );
+                    },
+                  ),
                 ),
               );
             },

--- a/lib/widgets/top_image_list/top_image_list.dart
+++ b/lib/widgets/top_image_list/top_image_list.dart
@@ -57,7 +57,7 @@ class _ImagesWidget extends StatelessWidget {
             ),
             itemBuilder: (context, index) {
               return GestureDetector(
-                onTap: () => Navigator.push(context, MaterialPageRoute(builder: (context) => ImageDetailPage())),
+                onTap: () => Navigator.push(context, MaterialPageRoute(builder: (context) => ImageDetailPage(snapshot.data[index]))),
                 child: Container(
                   decoration: BoxDecoration(
                     border: Border.all(color: Colors.black45),

--- a/lib/widgets/top_image_list/top_image_list.dart
+++ b/lib/widgets/top_image_list/top_image_list.dart
@@ -46,7 +46,7 @@ class _ImagesWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     TopImagesBloc bloc = Provider.of<TopImagesBloc>(context);
     return Container(
-      child: StreamBuilder<List<String>>(
+      child: StreamBuilder<List<DocumentSnapshot>>(
         stream: bloc.imagesValue,
         initialData: const [],
         builder: (context, snapshot) {
@@ -65,7 +65,7 @@ class _ImagesWidget extends StatelessWidget {
                   child: Image(
                     fit: BoxFit.fitWidth,
                     image: (snapshot.hasData)
-                      ? NetworkImage(snapshot.data[index])
+                      ? NetworkImage(snapshot.data[index].data['url'])
                       : Card(color: Colors.orange,),
                     loadingBuilder: (BuildContext context, Widget child, ImageChunkEvent loadingProgress) {
                       if (loadingProgress == null) {

--- a/lib/widgets/top_image_list/top_image_list.dart
+++ b/lib/widgets/top_image_list/top_image_list.dart
@@ -63,7 +63,7 @@ class _ImagesWidget extends StatelessWidget {
                     border: Border.all(color: Colors.black45),
                   ),
                   child: Image(
-                    fit: BoxFit.cover,
+                    fit: BoxFit.fitWidth,
                     image: (snapshot.hasData)
                       ? NetworkImage(snapshot.data[index])
                       : Card(color: Colors.orange,),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -71,6 +71,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.3"
+  filesize:
+    dependency: "direct main"
+    description:
+      name: filesize
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.4"
   firebase:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   provider: ^4.0.1
   firebase_storage: ^3.1.1
   image_picker: ^0.6.3
+  filesize: ^1.0.4
 
 dev_dependencies:
   flutter_test:

--- a/test/model_tests/image_upload_bloc_test.dart
+++ b/test/model_tests/image_upload_bloc_test.dart
@@ -1,0 +1,41 @@
+
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image_share_app/models/image_upload_bloc.dart';
+import 'package:mockito/mockito.dart';
+
+class _MockImageUploadRepository extends Mock implements ImageUploadRepository {}
+
+void main() {
+
+  group("ImageUploadBlocのテスト", () {
+
+    test('pickUpImage()のテスト', () async {
+
+      ImageUploadRepository _repository = _MockImageUploadRepository();
+      ImageUploadBloc target = ImageUploadBloc(_repository);
+
+      when(_repository.getImageInGallery()).thenAnswer((_) => Future.value(File('test_resources/contacts.json')));
+
+      target.pickUpImage();
+
+      target.value.listen(
+        expectAsync1((actual) async {
+          final json = jsonDecode(await actual.readAsString());
+          final contacts = json['contacts'];
+
+          final seth = contacts.first;
+          expect(seth['id'], 1);
+          expect(seth['name'], 'Seth Ladd');
+
+          final eric = contacts.last;
+          expect(eric['id'], 2);
+          expect(eric['name'], 'Eric Seidel');
+        })
+      );
+    });
+  });
+}

--- a/test/model_tests/room_list_bloc_test.dart
+++ b/test/model_tests/room_list_bloc_test.dart
@@ -1,5 +1,4 @@
 
-
 import 'package:cloud_firestore/cloud_firestore.dart';
 import "package:flutter_test/flutter_test.dart";
 import 'package:image_share_app/models/room_list_bloc.dart';

--- a/test_resources/contacts.json
+++ b/test_resources/contacts.json
@@ -1,0 +1,12 @@
+{
+  "contacts": [
+    {
+      "id": 1,
+      "name": "Seth Ladd"
+    },
+    {
+      "id": 2,
+      "name": "Eric Seidel"
+    }
+  ]
+}


### PR DESCRIPTION
- デバッグ用のパッケージを追加
- ImageUploadBlocクラスのテストコードを追加
- 画像の詳細ページを表示するためのfileを作成
- 一覧の画像をタップすると詳細画面に遷移するように変更
- 設定変更
- 画像詳細ページのレイアウト作成(1)
- 画像詳細のオリジナル画像を取得するBlocファイルを作成
- 詳細ページに表示させる画像のURLをオリジナルのものに変更