### PR TITLE
Feature/issue0125

### DIFF
--- a/lib/models/editing_profile_bloc.dart
+++ b/lib/models/editing_profile_bloc.dart
@@ -1,0 +1,56 @@
+
+
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:image_share_app/widgets/commont_widgets/common_loading_widget.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class EditingProfileBloc extends AbstractLoadingBloc {
+
+  final EditingProfileRepository _repository;
+
+  final StreamController<LoadingType> _loadingController = StreamController();
+  Stream<LoadingType> get loadingValue => _loadingController.stream;
+
+  EditingProfileBloc(this._repository);
+
+  void editingName(String name) async {
+    _loadingController.sink.add(LoadingType.LOADING);
+    await _repository.setNickNameIntoLocalStorage(name);
+    await _repository.setNickNameIntoFireStore(name);
+    _loadingController.sink.add(LoadingType.COMPLETED);
+  }
+
+  void dispose() {
+    _loadingController.close();
+  }
+}
+
+class EditingProfileRepository {
+
+  /// ローカルストレージに名前を保存する関数
+  void setNickNameIntoLocalStorage(String name) async {
+
+    final SharedPreferences _prefs = await SharedPreferences.getInstance();
+    await _prefs.setString('name', name);
+  }
+
+  /// FireStoreに名前を保存する関数
+  void setNickNameIntoFireStore(String name) async {
+
+    final SharedPreferences _prefs = await SharedPreferences.getInstance();
+    final _uid = _prefs.getString('uid');
+
+    await Firestore.instance.collection('users').where('userId', isEqualTo: _uid)
+      .getDocuments()
+      .then((docs) {
+        if (docs.documents.first.reference != null) {
+          docs.documents.first.reference.updateData({
+            'name': name
+          });
+        }
+      }).catchError((e) => debugPrint(e.toString()));
+  }
+}

--- a/lib/models/room_settings_bloc.dart
+++ b/lib/models/room_settings_bloc.dart
@@ -16,6 +16,9 @@ class RoomSettingsBloc {
   final _participantsController  = StreamController<List<DocumentSnapshot>>();
   Stream<List<DocumentSnapshot>> get participantsStream => _participantsController.stream;
 
+  final StreamController<DocumentSnapshot> _myProfileController = StreamController();
+  Stream<DocumentSnapshot> get myProfileStream => _myProfileController.stream;
+
   final _loadingController = StreamController<LoadingType>();
   Stream<LoadingType> get loadingStream => _loadingController.stream;
 
@@ -48,7 +51,9 @@ class RoomSettingsBloc {
     for (final ref in _refs) {
       await ref.get().then((data) {
         // 自分以外のメンバーを追加
-        if (data.data['userId'].toString() != _userId) {
+        if (data.data['userId'].toString() == _userId) {
+          _myProfileController.sink.add(data);
+        } else {
           _participants.add(data);
         }
       }).catchError((e) {
@@ -60,6 +65,7 @@ class RoomSettingsBloc {
 
   void dispose() {
     _participantsController.close();
+    _myProfileController.close();
     _loadingController.close();
   }
 }

--- a/lib/widgets/room_settings/editing_profile_page.dart
+++ b/lib/widgets/room_settings/editing_profile_page.dart
@@ -1,17 +1,29 @@
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:image_share_app/models/editing_profile_bloc.dart';
+import 'package:image_share_app/widgets/commont_widgets/common_loading_widget.dart';
+import 'package:provider/provider.dart';
 
 class EditingProfilePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
     // TODO: implement build
-    return GestureDetector(
-      onTap: () => FocusScope.of(context).requestFocus(FocusNode()),
-      child: Scaffold(
-        appBar: AppBar(title: const Text('編集'),),
-        body: _EditingProfileWidget()
+    return Provider<EditingProfileBloc>(
+      create: (_) => EditingProfileBloc(EditingProfileRepository()),
+      dispose: (_, bloc) => bloc.dispose(),
+      child: Stack(
+        children: <Widget>[
+          GestureDetector(
+            onTap: () => FocusScope.of(context).requestFocus(FocusNode()),
+            child: Scaffold(
+              appBar: AppBar(title: const Text('編集'),),
+              body: _EditingProfileWidget()
+            ),
+          ),
+          CommonLoadingWidget<EditingProfileBloc>(dialogTitle: '名前の変更',)
+        ],
       ),
     );
   }
@@ -23,6 +35,7 @@ class _EditingProfileWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final EditingProfileBloc _bloc = Provider.of<EditingProfileBloc>(context, listen: false);
     return Padding(
       padding: const EdgeInsets.all(20),
       child: Column(
@@ -34,13 +47,15 @@ class _EditingProfileWidget extends StatelessWidget {
               border: const UnderlineInputBorder(),
               labelText: 'ニックネーム',
             ),
-            obscureText: true,
           ),
           const SizedBox(height: 30,),
           FlatButton(
             child: const Text('編集'),
             onPressed: () {
-
+              final String _name = _nickNameController.text;
+              if (_name != null && _name.isNotEmpty) {
+                _bloc.editingName(_name);
+              }
             },
             color: Colors.white,
             shape: const OutlineInputBorder(

--- a/lib/widgets/room_settings/editing_profile_page.dart
+++ b/lib/widgets/room_settings/editing_profile_page.dart
@@ -1,0 +1,26 @@
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class EditingProfilePage extends StatelessWidget {
+
+  final TextEditingController _nickNameController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO: implement build
+    return Scaffold(
+      appBar: AppBar(title: const Text('編集'),),
+      body: Center(
+        child: TextFormField(
+          controller: _nickNameController,
+          decoration: const InputDecoration(
+            border: const UnderlineInputBorder(),
+            labelText: 'ニックネーム',
+          ),
+          obscureText: true,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/room_settings/editing_profile_page.dart
+++ b/lib/widgets/room_settings/editing_profile_page.dart
@@ -12,13 +12,16 @@ class EditingProfilePage extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(title: const Text('編集'),),
       body: Center(
-        child: TextFormField(
-          controller: _nickNameController,
-          decoration: const InputDecoration(
-            border: const UnderlineInputBorder(),
-            labelText: 'ニックネーム',
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: TextFormField(
+            controller: _nickNameController,
+            decoration: const InputDecoration(
+              border: const UnderlineInputBorder(),
+              labelText: 'ニックネーム',
+            ),
+            obscureText: true,
           ),
-          obscureText: true,
         ),
       ),
     );

--- a/lib/widgets/room_settings/editing_profile_page.dart
+++ b/lib/widgets/room_settings/editing_profile_page.dart
@@ -4,17 +4,31 @@ import 'package:flutter/material.dart';
 
 class EditingProfilePage extends StatelessWidget {
 
+  @override
+  Widget build(BuildContext context) {
+    // TODO: implement build
+    return GestureDetector(
+      onTap: () => FocusScope.of(context).requestFocus(FocusNode()),
+      child: Scaffold(
+        appBar: AppBar(title: const Text('編集'),),
+        body: _EditingProfileWidget()
+      ),
+    );
+  }
+}
+
+class _EditingProfileWidget extends StatelessWidget {
+
   final TextEditingController _nickNameController = TextEditingController();
 
   @override
   Widget build(BuildContext context) {
-    // TODO: implement build
-    return Scaffold(
-      appBar: AppBar(title: const Text('編集'),),
-      body: Center(
-        child: Padding(
-          padding: const EdgeInsets.all(20),
-          child: TextFormField(
+    return Padding(
+      padding: const EdgeInsets.all(20),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          TextFormField(
             controller: _nickNameController,
             decoration: const InputDecoration(
               border: const UnderlineInputBorder(),
@@ -22,7 +36,19 @@ class EditingProfilePage extends StatelessWidget {
             ),
             obscureText: true,
           ),
-        ),
+          const SizedBox(height: 30,),
+          FlatButton(
+            child: const Text('編集'),
+            onPressed: () {
+
+            },
+            color: Colors.white,
+            shape: const OutlineInputBorder(
+              borderRadius: BorderRadius.all(Radius.circular(10.0)),
+            ),
+            highlightColor: Colors.blue,
+          )
+        ],
       ),
     );
   }

--- a/lib/widgets/room_settings/room_settings_page.dart
+++ b/lib/widgets/room_settings/room_settings_page.dart
@@ -40,7 +40,27 @@ class RoomSettingsBodyPage extends StatelessWidget {
     return Provider<RoomSettingsBloc>(
       create: (_) => RoomSettingsBloc(_roomInfo),
       dispose: (_, bloc) => bloc.dispose(),
-      child: RoomMembersPage()
+      child: Column(
+        children: <Widget>[
+          // メンバー一覧のヘッダー
+          Container(
+            padding: const EdgeInsets.all(15),
+            decoration: BoxDecoration(
+                border: Border(
+                    bottom: BorderSide(color: Colors.black38)
+                )
+            ),
+            child: Center(
+              child: Text(
+                '参加している人',
+                style: Theme.of(context).textTheme.headline,
+              ),
+            ),
+          ),
+          // メンバー一覧
+          RoomMembersPage(),
+        ],
+      )
     );
   }
 }
@@ -55,44 +75,29 @@ class RoomMembersPage extends StatelessWidget {
       stream: _bloc.participantsStream,
       builder: (context, snapshot) {
         return ListView.builder(
-            itemBuilder: (BuildContext context, int index) {
-              // ヘッダー
-              if (index == 0) {
-                return Container(
-                  padding: const EdgeInsets.all(15),
-                  decoration: BoxDecoration(
-                    border: Border(
-                      bottom: BorderSide(color: Colors.black38)
-                    )
+          shrinkWrap: true,
+          physics: const ScrollPhysics(),
+          itemBuilder: (BuildContext context, int index) {
+            if (snapshot.hasData) {
+              return Container(
+                margin:  const EdgeInsets.all(5),
+                decoration: BoxDecoration(
+                  border: Border(
+                    bottom: BorderSide(color: Colors.black38)
+                  )
+                ),
+                child: ListTile(
+                  title: Text(
+                    (snapshot.data[index].data['nickName'] != null) ? snapshot.data[index].data['nickName'].toString() : 'GUEST${index + 1}',
+                    style: const TextStyle(fontSize: 20),
                   ),
-                  child: Center(
-                    child: Text(
-                      '参加している人',
-                      style: Theme.of(context).textTheme.headline,
-                    ),
-                  ),
-                );
-              }
-              if (snapshot.hasData) {
-                return Container(
-                  margin:  const EdgeInsets.all(5),
-                  decoration: BoxDecoration(
-                    border: Border(
-                      bottom: BorderSide(color: Colors.black38)
-                    )
-                  ),
-                  child: ListTile(
-                    title: Text(
-                      (snapshot.data[index - 1].data['nickName'] != null) ? snapshot.data[index - 1].data['nickName'].toString() : 'GUEST${index}',
-                      style: const TextStyle(fontSize: 20),
-                    ),
-                  ),
-                );
-              } else {
-                return Container();
-              }
-            },
-            itemCount: (snapshot.hasData) ? snapshot.data.length + 1 : 0,
+                ),
+              );
+            } else {
+              return Container();
+            }
+          },
+          itemCount: (snapshot.hasData) ? snapshot.data.length : 0,
         );
       },
     );

--- a/lib/widgets/room_settings/room_settings_page.dart
+++ b/lib/widgets/room_settings/room_settings_page.dart
@@ -42,6 +42,7 @@ class RoomSettingsBodyPage extends StatelessWidget {
       dispose: (_, bloc) => bloc.dispose(),
       child: Column(
         children: <Widget>[
+          _MyProfileInfoWidget(),
           // メンバー一覧のヘッダー
           Container(
             padding: const EdgeInsets.all(15),
@@ -65,11 +66,58 @@ class RoomSettingsBodyPage extends StatelessWidget {
   }
 }
 
+// 自分の名前を表示するWidget
+class _MyProfileInfoWidget extends StatelessWidget {
+
+  @override
+  Widget build(BuildContext context) {
+    final _bloc = Provider.of<RoomSettingsBloc>(context, listen: false);
+    _bloc.fetchRoomMembersWithLoading();
+    return StreamBuilder<DocumentSnapshot>(
+      stream: _bloc.myProfileStream,
+      builder: (context, snapshot) {
+        if (snapshot.hasData) {
+          return Container(
+            margin:  const EdgeInsets.all(5),
+            decoration: BoxDecoration(
+                border: Border(
+                    bottom: BorderSide(color: Colors.black38)
+                )
+            ),
+            child: ListTile(
+              title: Text(
+                (snapshot.data.data['nickName'] != null) ? snapshot.data.data['nickName'].toString() : '名無し',
+                style: const TextStyle(fontSize: 20),
+              ),
+            ),
+          );
+        } else {
+          return Container(
+            margin:  const EdgeInsets.all(5),
+            decoration: BoxDecoration(
+                border: Border(
+                    bottom: BorderSide(color: Colors.black38)
+                )
+            ),
+            child: const ListTile(
+              title: Text(
+                '名無し',
+                style: const TextStyle(fontSize: 20),
+              ),
+            ),
+          );
+        }
+      },
+    );
+  }
+}
+
+// 部屋に参加しているメンバーの名前を表示するWidget
 class RoomMembersPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final _bloc = Provider.of<RoomSettingsBloc>(context);
+    final _bloc = Provider.of<RoomSettingsBloc>(context, listen: false);
     _bloc.fetchRoomMembersWithLoading();
     return StreamBuilder<List<DocumentSnapshot>>(
       stream: _bloc.participantsStream,

--- a/lib/widgets/room_settings/room_settings_page.dart
+++ b/lib/widgets/room_settings/room_settings_page.dart
@@ -102,7 +102,7 @@ class _MyProfileInfoWidget extends StatelessWidget {
             ),
             child: ListTile(
               title: Text(
-                (snapshot.data.data['nickName'] != null) ? snapshot.data.data['nickName'].toString() : '名無し',
+                (snapshot.data.data['name'] != null) ? snapshot.data.data['name'].toString() : '名無し',
                 style: const TextStyle(fontSize: 20),
               ),
               onTap: () => Navigator.of(context).push(MaterialPageRoute(builder: (context) => EditingProfilePage()))

--- a/lib/widgets/room_settings/room_settings_page.dart
+++ b/lib/widgets/room_settings/room_settings_page.dart
@@ -42,6 +42,21 @@ class RoomSettingsBodyPage extends StatelessWidget {
       dispose: (_, bloc) => bloc.dispose(),
       child: Column(
         children: <Widget>[
+          Container(
+            padding: const EdgeInsets.all(15),
+            decoration: BoxDecoration(
+                border: Border(
+                    bottom: BorderSide(color: Colors.black38)
+                )
+            ),
+            child: Center(
+              child: Text(
+                'あなた',
+                style: Theme.of(context).textTheme.headline,
+              ),
+            ),
+          ),
+          // 自分の名前
           _MyProfileInfoWidget(),
           // メンバー一覧のヘッダー
           Container(

--- a/lib/widgets/room_settings/room_settings_page.dart
+++ b/lib/widgets/room_settings/room_settings_page.dart
@@ -73,7 +73,6 @@ class RoomMembersPage extends StatelessWidget {
                   ),
                 );
               }
-
               if (snapshot.hasData) {
                 return Container(
                   margin:  const EdgeInsets.all(5),
@@ -84,7 +83,7 @@ class RoomMembersPage extends StatelessWidget {
                   ),
                   child: ListTile(
                     title: Text(
-                      snapshot.data[index - 1].data['email'].toString(),
+                      (snapshot.data[index - 1].data['nickName'] != null) ? snapshot.data[index - 1].data['nickName'].toString() : 'GUEST${index}',
                       style: const TextStyle(fontSize: 20),
                     ),
                   ),

--- a/lib/widgets/room_settings/room_settings_page.dart
+++ b/lib/widgets/room_settings/room_settings_page.dart
@@ -4,6 +4,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:image_share_app/models/room_settings_bloc.dart';
 import 'package:image_share_app/widgets/room_settings/add_member_page.dart';
+import 'package:image_share_app/widgets/room_settings/editing_profile_page.dart';
 import 'package:provider/provider.dart';
 
 class RoomSettingsPage extends StatelessWidget {
@@ -104,6 +105,7 @@ class _MyProfileInfoWidget extends StatelessWidget {
                 (snapshot.data.data['nickName'] != null) ? snapshot.data.data['nickName'].toString() : '名無し',
                 style: const TextStyle(fontSize: 20),
               ),
+              onTap: () => Navigator.of(context).push(MaterialPageRoute(builder: (context) => EditingProfilePage()))
             ),
           );
         } else {
@@ -114,11 +116,12 @@ class _MyProfileInfoWidget extends StatelessWidget {
                     bottom: BorderSide(color: Colors.black38)
                 )
             ),
-            child: const ListTile(
-              title: Text(
+            child: ListTile(
+              title: const Text(
                 '名無し',
                 style: const TextStyle(fontSize: 20),
               ),
+              onTap: () => Navigator.of(context).push(MaterialPageRoute(builder: (context) => EditingProfilePage()))
             ),
           );
         }


### PR DESCRIPTION
- ルームメンバーを表示する一覧の名前を変更
- メンバー一覧のヘッダーを修正
- 自分の情報を取得するStreamControllerを追加
- 自分の名前を表示するWidgetを追加
- 自分の名前を変更できるページを作成
- 名前を編集するページのレイアウトを作成
- 名前編集ページに遷移する処理を追加
- 名前を入力する欄にpaddingを追加
- 名前を編集するページのBlocファイルを作成
- 名前を編集するためのビジネスロジックを追加
- レイアウトの修正
- 編集ボタンを押した時、名前を編集できるように変更
- modify